### PR TITLE
Feature/use different hash for sqlite

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Creates and manages connections against a database, using sequelize.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/connection_factory.ts
+++ b/src/connection_factory.ts
@@ -23,7 +23,13 @@ const connections: {[hash: string]: Sequelize.Sequelize} = {};
  */
 export async function getConnection(config: Sequelize.Options): Promise<Sequelize.Sequelize> {
 
-  const hash: string = _getHash(config.database, config.username, config.password);
+  let hash: string;
+
+  if (config.dialect === 'sqlite') {
+    hash = _getHash(config.storage, config.username, config.password);
+  } else {
+    hash = _getHash(config.database, config.username, config.password);
+  }
 
   const connectionExists: boolean = typeof connections[hash] !== 'undefined';
 


### PR DESCRIPTION
Closes #4 

## What did you change?

Add a switch, which checks for the type of `dialect` being used. 
When `sqlite` is being used, the config value for `storage` will be included in the hash generation. Otherwise, the standard `database` property is used.

## How can others test the changes?

Use the connection manager to create different sqlite connections to multiple storages. Each of the connections should get its own hash.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
