### PR TITLE
📦 Configure retry-option for queries failing with SQL_BUSY

### DIFF
--- a/src/sequelize_connection_manager.ts
+++ b/src/sequelize_connection_manager.ts
@@ -54,9 +54,10 @@ export class SequelizeConnectionManager {
 
     config.retry = {
       match: [
+         /SQL_BUSY/,
          /SQLITE_BUSY/,
        ],
-      max: 10,
+      max: 50,
     };
 
     const connection: Sequelize.Sequelize = new Sequelize(dbToUse, config.username, config.password, config);

--- a/src/sequelize_connection_manager.ts
+++ b/src/sequelize_connection_manager.ts
@@ -52,6 +52,13 @@ export class SequelizeConnectionManager {
       }
     }
 
+    config.retry = {
+      match: [
+         /SQLITE_BUSY/,
+       ],
+      max: 10,
+    };
+
     const connection: Sequelize.Sequelize = new Sequelize(dbToUse, config.username, config.password, config);
     logger.info(`Connection to database '${dbToUse}' established.`);
     this.connections[hash] = connection;


### PR DESCRIPTION
**Changes:**

1. Configure `retry` option for Sequelize Connections
    - Retry is to be done for `BUSY` errors.
    - Max retry amount is 50.

Background info:
When executing multiple transactions with sequelize, it may happen that the native sqlite library throws a `SQLITE_BUSY` Error to all lingering transactions. 
The problem is, that neither the node-sqlite adapter, nor sequelize is able to handle this error correctly. The only way working around that is to retry a transaction which failed with this error.

The choosen value for the maximal retry count is kinda random. Maybe it should be externally configurable. 

Interesting: Event the Sequlize Documentation mentioned this kind of issue in their config  - documentation for the `retry.max` parameter: 

>  options.retry.max:  How many times a failing query is automatically retried. Set to 0 to **disable retrying on SQL_BUSY error**.

found here: http://docs.sequelizejs.com/class/lib/sequelize.js~Sequelize.html

**Issues:**

Related: https://github.com/process-engine/process_engine_runtime/issues/287

PR: #9 

## How can others test the changes?

See in the linked issed. 

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).